### PR TITLE
Fix typo in "Route 25 - Man Gift" tags

### DIFF
--- a/worlds/pokemon_frlg/data/locations.json
+++ b/worlds/pokemon_frlg/data/locations.json
@@ -538,7 +538,7 @@
   },
   "NPC_GIFT_GOT_CERULEAN_KEY": {
     "name": "Route 25 - Man Gift",
-    "tags": ["NPC Gifts", "Kanto", "Rotue 25"],
+    "tags": ["NPC Gifts", "Kanto", "Route 25"],
     "category": "NPC_GIFT",
     "include": ["Gym Keys"]
   },


### PR DESCRIPTION
"Rotue 25" -> "Route 25"

I noticed this while looking at the location groups in the datapackage.

Github automatically added the newline at the end of the file.