### PR TITLE
Pokemon FRLG: Work around option creator snapping to range after options are changed

### DIFF
--- a/worlds/pokemon_frlg/options.py
+++ b/worlds/pokemon_frlg/options.py
@@ -1001,7 +1001,7 @@ class ForceFullyEvolved(NamedRange):
     """
     display_name = "Force Fully Evolved"
     default = 0
-    range_start = 1
+    range_start = -1
     range_end = 100
     special_range_names = {
         "never": 0,
@@ -1337,7 +1337,7 @@ class HmCompatibility(NamedRange):
     """
     display_name = "HM Compatibility"
     default = -1
-    range_start = 0
+    range_start = -1
     range_end = 100
     special_range_names = {
         "vanilla": -1,
@@ -1352,7 +1352,7 @@ class TmTutorCompatibility(NamedRange):
     """
     display_name = "TM/Tutor Compatibility"
     default = -1
-    range_start = 0
+    range_start = -1
     range_end = 100
     special_range_names = {
         "vanilla": -1,


### PR DESCRIPTION
Copied from James you can give him the credit

## What is this fixing or adding?

creator snapping to range after options are changed

## How was this tested?

Worked for Pokemon Crystal

