### PR TITLE
Fix priority species fallbacks overwriting each other during wild encounter randomization

### DIFF
--- a/worlds/pokemon_frlg/pokemon.py
+++ b/worlds/pokemon_frlg/pokemon.py
@@ -715,27 +715,48 @@ def randomize_wild_encounters(world: "PokemonFRLGWorld") -> None:
         if map_name == "MAP_ROUTE21_NORTH" or map_name == "MAP_ROUTE21_SOUTH":
             route_21_encounters = new_encounters
 
-    # If we failed to place Magikarp, Heracross, and/or Togepi put them in their vanilla spots
+    # Ensure Magikarp, Heracross, and Togepi are each present in at least one encounter.
+    # The main loop may fail to place them, and placing one can overwrite another (e.g.
+    # Magikarp replaces Heracross via species grouping, then Heracross gets force-placed
+    # back over those same slots). When that happens we cascade: any displaced priority
+    # species gets moved to its own fallback location.
     if world.options.pokemon_request_locations:
-        if data.constants["SPECIES_MAGIKARP"] in priority_species:
-            map_data = world.modified_maps["MAP_PALLET_TOWN"]
-            slots = map_data.encounters[EncounterType.FISHING].slots[game_version]
-            for i in [0, 1, 3]:
-                slots[i].species_id = data.constants["SPECIES_MAGIKARP"]
-
+        # Each entry: (map_name, encounter_type, slot_indices or None for all)
+        fallbacks: Dict[int, Tuple[str, EncounterType, List[int] | None]] = {
+            data.constants["SPECIES_MAGIKARP"]:
+                ("MAP_PALLET_TOWN", EncounterType.FISHING, [0, 1, 3]),
+        }
         if not world.options.kanto_only:
-            if data.constants["SPECIES_HERACROSS"] in priority_species:
-                map_data = world.modified_maps["MAP_SIX_ISLAND_PATTERN_BUSH"]
-                slots = map_data.encounters[EncounterType.LAND].slots[game_version]
-                for i in [5, 7, 9, 11]:
-                    slots[i].species_id = data.constants["SPECIES_HERACROSS"]
-
+            fallbacks[data.constants["SPECIES_HERACROSS"]] = \
+                ("MAP_SIX_ISLAND_PATTERN_BUSH", EncounterType.LAND, [5, 7, 9, 11])
             if world.options.famesanity:
-                if data.constants["SPECIES_TOGEPI"] in priority_species:
-                    map_data = world.modified_maps["MAP_FIVE_ISLAND_MEMORIAL_PILLAR"]
-                    slots = map_data.encounters[EncounterType.LAND].slots[game_version]
-                    for slot in slots:
-                        slot.species_id = data.constants["SPECIES_TOGEPI"]
+                fallbacks[data.constants["SPECIES_TOGEPI"]] = \
+                    ("MAP_FIVE_ISLAND_MEMORIAL_PILLAR", EncounterType.LAND, None)
+
+        placed_fallbacks: Set[int] = set()
+
+        def _place_at_fallback(species_id: int) -> None:
+            placed_fallbacks.add(species_id)
+            map_name, enc_type, indices = fallbacks[species_id]
+            md = world.modified_maps[map_name]
+            slots = md.encounters[enc_type].slots[game_version]
+            target = indices if indices is not None else range(len(slots))
+            displaced = set()
+            for i in target:
+                if slots[i].species_id in fallbacks and slots[i].species_id != species_id:
+                    displaced.add(slots[i].species_id)
+                slots[i].species_id = species_id
+            for d in displaced:
+                if d not in priority_species and d not in placed_fallbacks:
+                    _place_at_fallback(d)
+                elif d in placed_fallbacks:
+                    assert False, (f"Priority species fallback conflict: {data.species[d].name} "
+                                   f"was displaced after already being placed. "
+                                   f"Fallback locations must not overlap.")
+
+        for species_id in fallbacks:
+            if species_id in priority_species:
+                _place_at_fallback(species_id)
 
 
 def randomize_starters(world: "PokemonFRLGWorld") -> None:


### PR DESCRIPTION
When pokemon_request_locations is enabled, magikarp, heracross, and togepi are marked as priority species to ensure they appear in at least one wild encounter (required for "Show Pokemon" NPC gift locations).

If the main randomization loop fails to place a priority species, a fallback forces it into specific slots at its vanilla location. The bug occurs when species grouping causes one priority species to replace another during the main loop. For example:

1. magikarp and heracross are both priority species

2. The main loop maps heracross/magikarp globally (BST match). magikarp is placed in Pattern Bush (heracross' vanilla location) and removed from priority_species

3. heracross was the original species being replaced, so it's never "placed". It stays in priority_species

4. The heracross fallback fires and overwrites Pattern Bush slots [5,7,9,11] with jeracross, the same slots that were holding the only magikarp encounters

5. magikarp no longer exists in any encounter, making "Route 12 Fishing House - Fishing Guru Gift (Show Magikarp)" permanently unreachable.

6. AP becomes (rightfully so) sad and throws accessibility errors

The fix replaces the independent fallback blocks with a single _place_at_fallback function driven by a fallbacks dict that maps each priority species to its vanilla location (map, encounter type, slot indices). The outer loop is unchanged: it still only triggers for species the main loop failed to place (species_id in priority_species).

The new behavior is in what happens during placement: before overwriting a slot, the function checks whether the current occupant is itself a priority species. If so, it records it as displaced. After finishing the placement, any displaced species that was placed by the main loop (not in priority_species, meaning it won't get its own turn in the outer loop) is cascaded, _place_at_fallback is called recursively to move it to its own fallback location.

A placed_fallbacks set tracks which species have already been placed by the fallback pass, preventing infinite recursion if two fallbacks ever target the same map in the future.

Fixes the repro I have (see https://github.com/Eijebong/Archipelago-index/pull/1494#issuecomment-3940955766), fuzzed 10k with the same YAML as meta and 10k with complete random. Didn't see the issue once.